### PR TITLE
Use cross-env with environment variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "candidates": "APP_NAME=candidates webpack-dev-server --inline --progress --config build/webpack.dev.conf.js",
+    "candidates": "cross-env APP_NAME=candidates webpack-dev-server --inline --progress --config build/webpack.dev.conf.js",
     "start": "yarn candidates",
     "proxy": "node ./proxy.js",
     "lint": "eslint --ext .js,.vue src test/unit test/e2e/specs",
-    "build-candidates": "APP_NAME=candidates node ./build/build.js",
+    "build-candidates": "cross-env APP_NAME=candidates node ./build/build.js",
     "build": "yarn build-candidates"
   },
   "dependencies": {
@@ -37,7 +37,7 @@
     "babel-register": "^6.22.0",
     "chalk": "^2.0.1",
     "copy-webpack-plugin": "^4.0.1",
-    "cross-env": "^5.0.1",
+    "cross-env": "^5.2.0",
     "cross-spawn": "^5.0.1",
     "css-loader": "^0.28.0",
     "dotenv": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2097,7 +2097,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-env@^5.0.1:
+cross-env@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
   integrity sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==


### PR DESCRIPTION
Closes #11 
Guess we should care about the people who use Windows, right? 😆 

cross-env "makes it so you can have a single command without worrying about setting or using the environment variable properly for the platform"