### PR TITLE
Chat: Parse newlines in displayed messages

### DIFF
--- a/src/candidates/profile/chat/shared/ChatMessage.vue
+++ b/src/candidates/profile/chat/shared/ChatMessage.vue
@@ -6,7 +6,7 @@
       </div>
       <div class="chat__message-box">
         <p class="chat__message-text">
-          {{ message.text }}
+          {{ message.text.trim() }}
         </p>
         <p class="chat__message-time">{{ message.chatFormatedDate }}</p>
       </div>

--- a/src/candidates/profile/chat/shared/ChatMessage.vue
+++ b/src/candidates/profile/chat/shared/ChatMessage.vue
@@ -80,6 +80,7 @@ export default {
     hyphens: auto;
     text-align: justify;
     box-sizing: border-box;
+    white-space: pre-line;
   }
   .chat__message-time {
     margin-top: 5px;

--- a/src/candidates/profile/chat/shared/ChatMessage.vue
+++ b/src/candidates/profile/chat/shared/ChatMessage.vue
@@ -57,6 +57,7 @@ export default {
       background-color: #FFFFFF;
       box-shadow: 0 0 15px 2px rgba(207, 216, 220, .8);
       color: #455A64;
+      white-space: pre-line;
     }
     .chat__message-time {
       max-width: 430px;
@@ -70,7 +71,7 @@ export default {
   }
   .chat__message-text {
     margin-left: auto;
-    padding: 15px;
+    padding: 0px 15px 15px 15px;
     font-size: 14px;
     line-height: 1.3em;
     border-radius: 20px;


### PR DESCRIPTION
#2 

- tweaks CSS to display newline characters in the chat messages
- trims leading and trailing whitespace in the chat messages
