### PR TITLE
Fix the missing whitespaces on PDF parse

### DIFF
--- a/src/candidates/profile/cv_upload/CvUpload.vue
+++ b/src/candidates/profile/cv_upload/CvUpload.vue
@@ -71,7 +71,7 @@ const readPdfPagesContent = async (...args) => {
     // --- 2018-03-13 - lilsweetcaligula
     //
     const pageText = content.items
-      .reduce((acc, item) => acc + item.str, '');
+      .reduce((acc, item) => acc + ' ' + item.str, '');
 
     return pageText;
   });


### PR DESCRIPTION
#45 

Who would know that the solution would be so easy?

How it works: `item.str` always seems to be either a word or a whitespace string. Some whitespace strings are omitted. By adding extra whitespace, now all words are properly separated, at the cost of extra whitespace where it was not originally omitted.

This should unblock issue #37.

