### PR TITLE
Fix window is not defined error in pdf parsing

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -44,7 +44,8 @@ module.exports = {
     filename: '[name].js',
     publicPath: process.env.NODE_ENV === 'production'
       ? config.build.assetsPublicPath
-      : config.dev.assetsPublicPath
+      : config.dev.assetsPublicPath,
+    globalObject: 'this'
   },
   resolve: {
     extensions: ['.js', '.vue', '.json', '.css'],


### PR DESCRIPTION
Ref #43 

I've tested it out locally in both `yarn candidates` and `yarn build && yarn static` modes and it seems to work for me, but I think we'll test it more when it will be deployed to development environment.