### PR TITLE
Fix postcss-custom-media options

### DIFF
--- a/build/utils.js
+++ b/build/utils.js
@@ -30,14 +30,18 @@ const buildcssLoaders = function (options) {
       sourceMap: options.sourceMap,
       plugins: (loader) => [
         require('postcss-import'),
-        require("postcss-custom-media")({ extensions: {
-          '--phone-viewport': '(max-width: 30em)', // 480
-          '--phoneLarge-viewport': '(max-width: 36em)', // 576
-          '--tablet-viewport': '(max-width: 48em)', // 768
-          '--desktopSmall-viewport': '(max-width: 53em)', // 848
-          '--desktop-viewport': '(max-width: 60em)', // 960
-          '--desktopLarge-viewport': '(max-width: 77em)' // 1232
-        }}),
+        require("postcss-custom-media")({
+          importFrom: {
+            customMedia: {
+              '--phone-viewport': '(max-width: 30em)', // 480
+              '--phoneLarge-viewport': '(max-width: 36em)', // 576
+              '--tablet-viewport': '(max-width: 48em)', // 768
+              '--desktopSmall-viewport': '(max-width: 53em)', // 848
+              '--desktop-viewport': '(max-width: 60em)', // 960
+              '--desktopLarge-viewport': '(max-width: 77em)' // 1232
+            }
+          }
+        }),
         require('postcss-nested'),
         require('postcss-preset-env')()
       ]
@@ -45,7 +49,7 @@ const buildcssLoaders = function (options) {
   };
 
   // generate loader string to be used with extract text plugin
-  function generateLoaders (loader, loaderOptions) {
+  function generateLoaders(loader, loaderOptions) {
     const loaders =
       options.usePostCSS ? [cssLoader, postcssLoader] : [cssLoader];
 


### PR DESCRIPTION
The update to postcss-custom-media in #70 broke the processing of custom media queries (in Windows at least), as you can see from the screenshot below, from Chrome DevTools.
![image](https://user-images.githubusercontent.com/12294525/56732889-85bb3e00-6756-11e9-998f-68e1dc0f7312.png)
Seems like the "extensions" option used in this repo was deprecated (https://github.com/postcss/postcss-custom-media/issues/43).

This PR fixes this issue by using the "importFrom" option, together with the "customMedia" key.